### PR TITLE
don't cache generated service worker

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ function withWorkbox(nextConfig = {}) {
             cwd: dest,
             nodir: true,
           })
+          .filter((f) => f.indexOf(swDest) !== 0)
           .map((f) => ({
             url: `/${f}`,
             revision: getRevision(`public/${f}`),


### PR DESCRIPTION
Currently, since everything in the public directory is cached, the service worker will cache the service worker file. This pull request skips caching the service worker by filtering the files in the public dir.
As for the tests, I see that you don't test the part that scans the `public` directory, so I didn't write any tests for it.

closes #11 